### PR TITLE
Full height and width to ensure that the div fills the whole element.

### DIFF
--- a/resize-aware.html
+++ b/resize-aware.html
@@ -11,7 +11,9 @@
 				position: relative;
 			}
 			
-			saw {
+			#saw {
+				height: 100%;
+				width: 100%;
 				display: inline-block;
 				margin: 0px;
 				padding: 0px;


### PR DESCRIPTION
Otherwise, it was possible that percentual heights were not propagated correctly as the saw-div did not have the same height as the resize-aware element.
Also fixed the CSS style which refered to the element saw but was probably meant for the div with the id "saw"